### PR TITLE
Test for WS281x RGBW

### DIFF
--- a/decoder/test/rgb_led_ws281x/test.conf
+++ b/decoder/test/rgb_led_ws281x/test.conf
@@ -27,3 +27,8 @@ test ws2812b_neopixel24_4mhz_snippet
 	protocol-decoder rgb_led_ws281x channel din=0
 	input led/ws2812b_neopixel24/ws2812b_neopixel24_4mhz_snippet.sr
 	output rgb_led_ws281x annotation match ws2812b_neopixel24_4mhz_snippet.output
+
+test ws281x_rgbw_4mhz_snippet
+	protocol-decoder rgb_led_ws281x channel din=0 option type=RGBW
+	input led/ws281x_rgbw/ws281x_RGBW_4mhz_snippet.sr
+	output rgb_led_ws281x annotation match ws281x_RGBW_4mhz_snippet.output


### PR DESCRIPTION
yet dummy, as I could not execute the test myself.
Test data (ws281x_RGBW_4mhz_snippet.sr) is already available.