### PR TITLE
avr_isp: Fix Atmega device names in output after parts.py was updated

### DIFF
--- a/decoder/test/avr_isp/atmega328p_scan.output
+++ b/decoder/test/avr_isp/atmega328p_scan.output
@@ -3,3 +3,4 @@
 343940-348418 avr_isp: rsb0: "Vendor code: 0x1e (Atmel)"
 471874-476352 avr_isp: rsb1: "Part family / memory size: 0x95"
 599805-604283 avr_isp: rsb2: "Part number: 0x0f"
+471874-604283 avr_isp: dev: "Device: Atmel ATmega328P"

--- a/decoder/test/avr_isp/atmega88_erase_chip.output
+++ b/decoder/test/avr_isp/atmega88_erase_chip.output
@@ -3,7 +3,7 @@
 5121246-5122595 avr_isp: rsb0: "Vendor code: 0x1e (Atmel)"
 5137251-5138600 avr_isp: rsb1: "Part family / memory size: 0x93"
 5153263-5154611 avr_isp: rsb2: "Part number: 0x0a"
-5137251-5154611 avr_isp: dev: "Device: Atmel ATmega88"
+5137251-5154611 avr_isp: dev: "Device: Atmel ATmega88(A)"
 5169269-5170618 avr_isp: rfb: "Read fuse bits: 0xff"
 5184610-5185959 avr_isp: rfb: "Read fuse bits: 0xff"
 5201287-5202636 avr_isp: rfb: "Read fuse bits: 0xff"

--- a/decoder/test/avr_isp/atmega88_read_lfuse.output
+++ b/decoder/test/avr_isp/atmega88_read_lfuse.output
@@ -3,7 +3,7 @@
 5881971-5883320 avr_isp: rsb0: "Vendor code: 0x1e (Atmel)"
 5897965-5899314 avr_isp: rsb1: "Part family / memory size: 0x93"
 5913465-5914813 avr_isp: rsb2: "Part number: 0x0a"
-5897965-5914813 avr_isp: dev: "Device: Atmel ATmega88"
+5897965-5914813 avr_isp: dev: "Device: Atmel ATmega88(A)"
 5929981-5931328 avr_isp: rfb: "Read fuse bits: 0xff"
 5945990-5947339 avr_isp: rfb: "Read fuse bits: 0xff"
 5962014-5963363 avr_isp: rfb: "Read fuse bits: 0xff"

--- a/decoder/test/avr_isp/atmega88_scan.output
+++ b/decoder/test/avr_isp/atmega88_scan.output
@@ -3,7 +3,7 @@
 6460715-6462063 avr_isp: rsb0: "Vendor code: 0x1e (Atmel)"
 6476216-6477565 avr_isp: rsb1: "Part family / memory size: 0x93"
 6492733-6494082 avr_isp: rsb2: "Part number: 0x0a"
-6476216-6494082 avr_isp: dev: "Device: Atmel ATmega88"
+6476216-6494082 avr_isp: dev: "Device: Atmel ATmega88(A)"
 6508746-6510095 avr_isp: rfb: "Read fuse bits: 0xff"
 6524078-6525427 avr_isp: rfb: "Read fuse bits: 0xff"
 6540762-6542111 avr_isp: rfb: "Read fuse bits: 0xff"


### PR DESCRIPTION
parts.py for the avr_isp decoder was changed in https://github.com/sigrokproject/libsigrokdecode/commit/0235970293590f673a253950e6c61017cefa97df which altered the device names reported by the decoder. Test output files were updated accordingly.